### PR TITLE
Fix the loot command with the replace sub-command

### DIFF
--- a/kore/src/main/kotlin/io/github/ayfri/kore/commands/Loot.kt
+++ b/kore/src/main/kotlin/io/github/ayfri/kore/commands/Loot.kt
@@ -18,9 +18,9 @@ object Target {
 	fun give(targets: EntityArgument) = listOf(literal("give"), targets)
 	fun insert(pos: Vec3) = listOf(literal("insert"), pos)
 	fun spawn(pos: Vec3) = listOf(literal("spawn"), pos)
-	fun replaceBlock(pos: Vec3, slot: ItemSlotType, count: Int? = null) = listOfNotNull(literal("replace"), pos, slot, int(count))
+	fun replaceBlock(pos: Vec3, slot: ItemSlotType, count: Int? = null) = listOfNotNull(literal("replace"), literal("block"), pos, slot, int(count))
 	fun replaceEntity(entity: EntityArgument, slot: ItemSlotType, count: Int? = null) =
-		listOfNotNull(literal("replace"), entity, slot, int(count))
+		listOfNotNull(literal("replace"), literal("entity"), entity, slot, int(count))
 }
 
 @Serializable(Hand.Companion.HandSerializer::class)

--- a/kore/src/test/kotlin/io/github/ayfri/kore/commands/LootCommand.kt
+++ b/kore/src/test/kotlin/io/github/ayfri/kore/commands/LootCommand.kt
@@ -71,7 +71,7 @@ fun Function.lootTests() {
 		source {
 			loot(LootTables.Gameplay.CAT_MORNING_GIFT)
 		}
-	} assertsIs "loot replace ~ ~ ~ container.0 loot minecraft:gameplay/cat_morning_gift"
+	} assertsIs "loot replace block ~ ~ ~ container.0 loot minecraft:gameplay/cat_morning_gift"
 
 	loot {
 		target {
@@ -81,7 +81,7 @@ fun Function.lootTests() {
 		source {
 			loot(LootTables.Gameplay.CAT_MORNING_GIFT)
 		}
-	} assertsIs "loot replace ~ ~ ~ container.0 1 loot minecraft:gameplay/cat_morning_gift"
+	} assertsIs "loot replace block ~ ~ ~ container.0 1 loot minecraft:gameplay/cat_morning_gift"
 
 	loot {
 		target {
@@ -91,7 +91,7 @@ fun Function.lootTests() {
 		source {
 			loot(LootTables.Gameplay.CAT_MORNING_GIFT)
 		}
-	} assertsIs "loot replace @s armor.head loot minecraft:gameplay/cat_morning_gift"
+	} assertsIs "loot replace entity @s armor.head loot minecraft:gameplay/cat_morning_gift"
 
 	loot {
 		target {
@@ -101,5 +101,5 @@ fun Function.lootTests() {
 		source {
 			loot(LootTables.Gameplay.CAT_MORNING_GIFT)
 		}
-	} assertsIs "loot replace @s armor.head 1 loot minecraft:gameplay/cat_morning_gift"
+	} assertsIs "loot replace entity @s armor.head 1 loot minecraft:gameplay/cat_morning_gift"
 }


### PR DESCRIPTION
Just a simple fix for the loot replace command. Issue #73 